### PR TITLE
Refine post categories for clearer organization

### DIFF
--- a/src/content/posts/DockerMinecraft.md
+++ b/src/content/posts/DockerMinecraft.md
@@ -3,7 +3,7 @@ title: Docker-Minecraft-Server
 published: 2023-06-09
 tags: [ Docker ]
 description: "Este repositorio aloja los archivos necesarios para desplegar un servidor de Minecraft utilizando Docker Compose."
-category: IA
+category: DevOps
 draft: false
 ---
 

--- a/src/content/posts/HarmonyCSS.md
+++ b/src/content/posts/HarmonyCSS.md
@@ -3,7 +3,7 @@ title: HarmonyCSS
 published: 2023-12-30
 tags: [ CSS, web ]
 description: "HarmonyCSS se asemeja al agua en su versatilidad y capacidad para adaptarse al entorno del diseño web."
-category: IA
+category: Web
 draft: false
 ---
 

--- a/src/content/posts/IOT-esp32-Example.md
+++ b/src/content/posts/IOT-esp32-Example.md
@@ -3,7 +3,7 @@ title: IOT-esp32
 published: 2024-04-08
 tags: [Python, C++, Hardware developer]
 description: "Este es un ejemplo que presenté durante una conferencia donde fui invitada como ponente por Donweb."
-category: IA
+category: Hardware
 draft: false
 ---
 

--- a/src/content/posts/MermaidViewer.md
+++ b/src/content/posts/MermaidViewer.md
@@ -3,7 +3,7 @@ title: MermaidViewer
 published: 2025-08-19
 tags: [Mermaid, Javascript, Diagramas]
 description: "Un visor y editor de diagramas Mermaid directamente en tu navegador."
-category: IA
+category: Web
 draft: false
 ---
 

--- a/src/content/posts/Open-Virtual-Key.md
+++ b/src/content/posts/Open-Virtual-Key.md
@@ -3,7 +3,7 @@ title: Open-Virtual-Key
 published: 2022-12-09
 tags: [C++, Hardware developer ]
 description: "El Administrador de Contraseñas de Arduino es un sistema que te permite ingresar y almacenar contraseñas de manera segura"
-category: IA
+category: Hardware
 draft: false
 ---
 

--- a/src/content/posts/Windows-Miniconda-JupiterServer-Env copy 2.md
+++ b/src/content/posts/Windows-Miniconda-JupiterServer-Env copy 2.md
@@ -3,7 +3,7 @@ title: Windows-Miniconda-JupiterServer-Env
 published: 2024-04-08
 tags: [Python, IA]
 description: "Instalador Automatizado para Windows de Jupiter Server y Anaconda"
-category: IA
+category: DevOps
 draft: false
 ---
 


### PR DESCRIPTION
## Summary
- categorize hardware-related posts under a new "Hardware" category
- assign web-focused posts to a dedicated "Web" category
- move Docker and setup articles into a new "DevOps" category